### PR TITLE
Revert "Ink"

### DIFF
--- a/lib/doctype.js
+++ b/lib/doctype.js
@@ -139,8 +139,6 @@ function fromLanguage(id) {
             return new Standard_1.default({ comment_start: '#=', comment_end: '=#', comment_line: '#', string_inline: '"', string_quote: '\\' });
         case 'juliamarkdown':
             return new Markdown_1.default({ code_start: '~~~~(~)*', code_end: '' });
-        case 'ink':
-            return new Plaintext_1.default(({ comment_start: '\\/\\*', comment_end: '\\*\\/', comment_line: '//' }));
         default:
             return null;
     }


### PR DESCRIPTION
Reverts bartosz-antosik/vscode-spellright#81

Plaintext parser does not support comment_start/comment_end/comment_line parameters.