### PR TITLE
Add soft link instruction for Fedora users

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ On most Linux distributions system-wide dictionaries can be reused (for now only
 ln -s /usr/share/hunspell ~/.config/Code/Dictionaries
 ```
 
+On Fedora, system-wide dictionaries located under `myspell` instead of `hunspell`, so Fedora users use:
+
+```bash
+ln -s /usr/share/myspell ~/.config/Code/Dictionaries
+```
+
 Dictionaries from the folder will be listed in the language selection list and used for spelling documents. Because *Hunspell* engine is slower in serving suggestions to misspelled words it may be useful to set `spellright.suggestionsInHints` to `false` which will speed spelling up and suggestions will still be available in context menu called upon action for the suggestion.
 
 ### **User Dictionaries**


### PR DESCRIPTION
On Fedora, the built-in dictionary files are not located at `/usr/share/hunspell`, 
but rather at `/usr/share/myspell`.