### PR TITLE
Work around spellright crashing on remote.

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -11,10 +11,14 @@ global.SPELLRIGHT_MILLISECS_BATCH = 100;
 
 global.SPELLRIGHT_STATUSBAR_ITEM_PRIORITY = (-1);
 
-const spellright = require('./spellright');
 const vscode = require('vscode');
 
 function activate(context) {
+    if (vscode.env.remoteName) {
+        return;
+    }
+
+    const spellright = require('./spellright');
 
     if (SPELLRIGHT_DEBUG_OUTPUT) {
         console.log('[spellright] Activated (' + process.platform + ', ' + process.arch + ').');


### PR DESCRIPTION
This is a workaround for https://github.com/bartosz-antosik/vscode-spellright/issues/279. We have had several issues related to this reported on vscode's repos, and it's confusing every time. So this would keep the remote extension host from crashing at least.

You could also `console.log` here to explain why spellright isn't running.

On my end I am also looking into whether we can keep the EH from crashing in the first place.