### PR TITLE
Fixed "Remote Development"-bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "engines": {
     "vscode": "^1.46.0"
   },
+  "extensionKind": [
+		"ui"
+	],
   "categories": [
     "Other"
   ],


### PR DESCRIPTION
Fix for remote workflows where the extension is essentially disabled right now.

Adding the extensionkind flag as only 'ui' ensures that only the client machine is running the spellchecker locally.

See https://code.visualstudio.com/api/advanced-topics/remote-extensions for documentation.