### PR TITLE
Make extension work on remote hosts (e.g. WSL2)

### DIFF
--- a/lib/bin/node-spellchecker/build-linux-debian.sh
+++ b/lib/bin/node-spellchecker/build-linux-debian.sh
@@ -25,3 +25,7 @@ cp build/Release/spellchecker.node ../spellchecker-deb-11.1.0-ia32.node
 
 node-gyp rebuild --target=11.1.0 --arch=x64 --dist-url=https://atom.io/download/electron
 cp build/Release/spellchecker.node ../spellchecker-deb-11.1.0-x64.node
+
+# Build for headless VS Code Server (uses plain nodejs, not electron).
+node-gyp rebuild --target=12.14.1 --arch=x64 # --dist-url=https://atom.io/download/electron
+cp build/Release/spellchecker.node ../spellchecker-deb-12.14.1-x64.node

--- a/src/extension.js
+++ b/src/extension.js
@@ -14,10 +14,6 @@ global.SPELLRIGHT_STATUSBAR_ITEM_PRIORITY = (-1);
 const vscode = require('vscode');
 
 function activate(context) {
-    if (vscode.env.remoteName) {
-        return;
-    }
-
     const spellright = require('./spellright');
 
     if (SPELLRIGHT_DEBUG_OUTPUT) {


### PR DESCRIPTION
1. Re-enable execution of extension on remote hosts (Was blocked in ea7fa8fcbe51275eab3e9a27fc3594b4ba4b3929).
2. Provide spellchecker built against nodejs, not electron, for headless VS Code Server. (I only considered the deb build script, you might need to adapt for rpm/macos build scripts as required)