### PR TITLE
Added a setting to sort the workspace dictionary

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,10 @@ assigns parser of generic type `code` (Source Code Parser) to `perl` (Perl) docu
 
 If set to true Spell Right will use document symbols (variable, function names etc.) when spelling source code documents. Significantly reduces number of misspelled words in doc-strings and in comments whenever a symbol used in code is used and the symbol does not disassemble to properly spelled parts using CamelCase, snake_case etc. separation.
 
+`"spellright.sortWorkspaceDictionary": false`
+
+If set to true Spell Right will keep the words in the workspace dictionary in alphabetical order. This can reduce the likelihood of merge conflicts when multiple people are adding words to the workspace dictionary.
+
 ## In-Document Commands
 
 Beside global settings following commands can be embedded inside spelled parts of the document (e.g.: comments, strings etc.):

--- a/package.json
+++ b/package.json
@@ -193,6 +193,12 @@
           "default": true,
           "scope": "resource",
           "description": "Enable/disable using document symbols when spelling using code parser (source code documents)."
+        },
+        "spellright.sortWorkspaceDictionary": {
+          "type": "boolean",
+          "default": false,
+          "scope": "window",
+          "description": "Enable/disable sorting of words in the workspace dictionary file."
         }
       }
     },

--- a/src/spellright.js
+++ b/src/spellright.js
@@ -1824,12 +1824,19 @@ var SpellRight = (function () {
         }
     }
 
-    SpellRight.prototype.addWordToDictionary = function (word, filename) {
+    SpellRight.prototype.addWordToDictionary = function (word, filename, sort = false) {
         if (!fs.existsSync(filename)) {
             fs.closeSync(fs.openSync(filename, 'w'));
         }
 
-        fs.appendFileSync(filename, word + os.EOL);
+        if (sort) {
+            let words = this.readDictionaryFile(filename);
+            words.push(word);
+            words.sort();
+            fs.writeFileSync(filename, words.join(os.EOL) + os.EOL);
+        } else {
+            fs.appendFileSync(filename, word + os.EOL);
+        }
     }
 
     SpellRight.prototype.addWordToWorkspaceDictionary = function (word, save) {
@@ -1837,7 +1844,7 @@ var SpellRight = (function () {
         if (helpers._WorkspaceDictionary.indexOf(word) < 0) {
             helpers._WorkspaceDictionary.push(word);
             if (save) {
-                this.addWordToDictionary(word, this.getWorkspaceDictionaryFilename());
+                this.addWordToDictionary(word, this.getWorkspaceDictionaryFilename(), settings.sortWorkspaceDictionary);
             }
             return true;
         }


### PR DESCRIPTION
Fixes #201 

I've added a `spellright.sortWorkspaceDictionary` setting. This setting defaults to false, so the existing behavior has not changed. When set to true, the words in the workspace dictionary will be saved in alphabetical order when a new word is added to that dictionary.