### PR TITLE
Add setting to customize path to the dictionaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ ln -s /usr/share/hunspell/* ~/.config/Code/Dictionaries
 
 The location may vary among distributions (e.g.: on Fedora Linux it is `/usr/share/myspell` etc.) It also has been suggested that some flavors of Linux require that the dictionary name [should not contain spaces and/or parentheses](https://github.com/bartosz-antosik/vscode-spellright/issues/264#issuecomment-480332688).
 
+It's also possible to specify custom path in the extension's settings (`customDictionariesPath`) instead.
+
 Dictionaries from the folder will be listed in the language selection list and used for spelling documents. Because *Hunspell* engine is slower in serving suggestions to misspelled words it may be useful to set `spellright.suggestionsInHints` to `false` which will speed spelling up and suggestions will still be available in context menu called upon action for the suggestion.
 
 ### **User Dictionaries**
@@ -167,6 +169,10 @@ This extension contributes the following settings (with default values):
 `"spellright.language": [ "" ]`
 
 Default language (dictionary/country name) used for spelling. Typically in a LANGUAGE (e.g.: "en", "fr", when `"spellright.groupDictionaries"` is `true`) or LANGUAGE-COUNTRY format (e.g.: "en-US", "en-GB", "fr-CA", "pl-PL", when  `"spellright.groupDictionaries"` is `false`). When *Hunspell* spelling engine is used (e.g. in Windows 7) this setting should be the name of the dictionary file without extension. In case `language` parameter is not set then language from OS locales is used.
+
+`"spellright.customDictionariesPath": ""`
+
+Custom path to the folder containing dictionaries.
 
 `"spellright.statusBarIndicator": true`
 

--- a/package.json
+++ b/package.json
@@ -27,11 +27,11 @@
       "title": "Spell Right configuration",
       "properties": {
         "spellright.customDictionariesPath": {
-					"type": "string",
-					"default": "",
-					"scope": "machine",
-					"description": "Custom path to the folder containing dictionaries."
-				},
+          "type": "string",
+          "default": "",
+          "scope": "machine",
+          "description": "Custom path to the folder containing dictionaries."
+        },
         "spellright.language": {
           "type": "array",
           "default": [],

--- a/package.json
+++ b/package.json
@@ -26,6 +26,12 @@
       "type": "object",
       "title": "Spell Right configuration",
       "properties": {
+        "spellright.customDictionariesPath": {
+					"type": "string",
+					"default": "",
+					"scope": "machine",
+					"description": "Custom path to the folder containing dictionaries."
+				},
         "spellright.language": {
           "type": "array",
           "default": [],

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "spellright.customDictionariesPath": {
           "type": "string",
           "default": "",
-          "scope": "machine",
+          "scope": "machine-overridable",
           "description": "Custom path to the folder containing dictionaries."
         },
         "spellright.language": {

--- a/src/spellright.js
+++ b/src/spellright.js
@@ -1926,40 +1926,43 @@ var SpellRight = (function () {
     };
 
     SpellRight.prototype.getDictionariesPath = function () {
-
-        var codeFolder = vscode.env.appName.replace("Visual Studio ", "");
-
-        if (process.platform == 'win32') {
-            // Regular version, workspace opened
-            if (process.env.VSCODE_PORTABLE) {
-                var sourcePath = path.join(process.env.VSCODE_PORTABLE, 'user-data');
-            } else {
-                var sourcePath = path.join(process.env.APPDATA, codeFolder);
+        if(settings.customDictionariesPath) {
+            var dictionaryPath = path.normalize(settings.customDictionariesPath);
+        } else {
+            var codeFolder = vscode.env.appName.replace("Visual Studio ", "");
+    
+            if (process.platform == 'win32') {
+                // Regular version, workspace opened
+                if (process.env.VSCODE_PORTABLE) {
+                    var sourcePath = path.join(process.env.VSCODE_PORTABLE, 'user-data');
+                } else {
+                    var sourcePath = path.join(process.env.APPDATA, codeFolder);
+                }
+            } else if (process.platform == 'darwin') {
+                if (process.env.VSCODE_PORTABLE) {
+                    var sourcePath = path.join(process.env.VSCODE_PORTABLE, 'user-data');
+                } else {
+                    var sourcePath = path.join(process.env.HOME, 'Library', 'Application Support', codeFolder);
+                }
+            } else if (process.platform == 'linux') {
+                if (process.env.VSCODE_PORTABLE) {
+                    var sourcePath = path.join(process.env.VSCODE_PORTABLE, 'user-data');
+                } else {
+                    var sourcePath = path.join(process.env.HOME, '.config', codeFolder);
+                }
             }
-        } else if (process.platform == 'darwin') {
-            if (process.env.VSCODE_PORTABLE) {
-                var sourcePath = path.join(process.env.VSCODE_PORTABLE, 'user-data');
-            } else {
-                var sourcePath = path.join(process.env.HOME, 'Library', 'Application Support', codeFolder);
-            }
-        } else if (process.platform == 'linux') {
-            if (process.env.VSCODE_PORTABLE) {
-                var sourcePath = path.join(process.env.VSCODE_PORTABLE, 'user-data');
-            } else {
-                var sourcePath = path.join(process.env.HOME, '.config', codeFolder);
-            }
+            var userRoot = path.normalize(sourcePath);
+    
+            var dictionaryPath;
+            if (process.platform == 'win32')
+                dictionaryPath = path.join(userRoot, 'Dictionaries');
+            else if (process.platform == 'darwin')
+                dictionaryPath = path.join(userRoot, 'Dictionaries');
+            else if (process.platform == 'linux')
+                dictionaryPath = path.join(userRoot, 'Dictionaries');
+            else
+                dictionaryPath = '';
         }
-        var userRoot = path.normalize(sourcePath);
-
-        var dictionaryPath;
-        if (process.platform == 'win32')
-            dictionaryPath = path.join(userRoot, 'Dictionaries');
-        else if (process.platform == 'darwin')
-            dictionaryPath = path.join(userRoot, 'Dictionaries');
-        else if (process.platform == 'linux')
-            dictionaryPath = path.join(userRoot, 'Dictionaries');
-        else
-            dictionaryPath = '';
 
         if (SPELLRIGHT_DEBUG_OUTPUT) {
             console.log('[spellright] Dictionaries path: \"' + dictionaryPath + '\"');


### PR DESCRIPTION
Unfortunately, on my machine (Arch Linux, Code OSS v1.62.0 with ["Marketplace addon"](https://aur.archlinux.org/packages/code-marketplace/) that modifies `product.json` file), this extensions fails to properly detect the directory containing Dictionaries (it detects `~/.config/Code/Dictionaries` instead of `~/.config/Code - OSS/Dictionaries`). 
The detection is based on the application's name, which is modified by the addon (the name is changed from `Code - OSS` to `Visual Studio Code`, but the config directory stays unchanged - `Code - OSS`).

This pull request adds a new setting - `spellright.customDictionariesPath` - that allows the user to specify custom path to the directory containing dictionaries. That also lets the user to skip soft-linking the dictionaries because they can just specify the path to the system-wide folder here. 
In case of an empty string, it fallbacks to the old method.

Of course, it would be better to somehow fix the automatic detection, but I'm not sure if it's even possible - I couldn't find any way to get the path to the VS Code config directory with the Extension API :confused: 