### PR TITLE
Handle SCM input text document

### DIFF
--- a/lib/doctype.js
+++ b/lib/doctype.js
@@ -119,6 +119,7 @@ function fromLanguage(id) {
             return new Code_1.default({ comment_start: '\\(\\*', comment_end: '\\*\\)', comment_line: '\\/\\/' });
         case 'git-commit':
         case 'git-rebase':
+        case 'scminput':
             return new Plaintext_1.default();
         case 'handlebars':
             return new Xml_1.default(true);

--- a/src/spellright.js
+++ b/src/spellright.js
@@ -1386,9 +1386,10 @@ var SpellRight = (function () {
             return;
         }
 
-        // Is this a private URI? (VSCode started having 'private:' versions
-        // of non-plaintext documents with languageId = 'plaintext')
-        if (_document.uri.scheme != 'file' && _document.uri.scheme != 'untitled') {
+        // * Is this a private URI? (VSCode started having 'private:' versions of non-plaintext documents with languageId = 'plaintext')
+        // * The text document of the SCM input field is being exposed with the "vscode" scheme and "scminput" languageId. In order to be
+        //   able to provide spell check for the SCM input field, we do need to process this text document.
+        if (_document.uri.scheme != 'file' && _document.uri.scheme != 'untitled' && _document.languageId != 'scminput') {
             return;
         }
 


### PR DESCRIPTION
👋🏻 I am a member of the VS Code team and I've been looking at a long standing feature request (https://github.com/microsoft/vscode/issues/35571) to add spell check to the source control input field. As it turns out all the necessary extension api is present to enable this functionality in your extension. The text document behind the input field is surfaced with the scheme of `vscode` and languageId of `scminput`. This pull request adds support for handling such documents. Please take a look and let me know what you think. Thanks!