### PR TITLE
enable support for quarto documents

### DIFF
--- a/lib/doctype.js
+++ b/lib/doctype.js
@@ -149,6 +149,8 @@ function fromLanguage(id) {
             return new Markdown_1.default({ code_start: '----(-)*', code_end: '' });
         case 'rmd':
             return new Markdown_1.default({ code_start: '\`\`\`', code_end: '', code_line: '^ {4,}\\s*(?!(<!|\\`\\`\\`|\\*\\s|\\+\\s|\\-\\s|\\d+\\s))\\S+'  });
+        case 'quarto':
+            return new Markdown_1.default({ code_start: '\`\`\`', code_end: '', code_line: '^ {4,}\\s*(?!(<!|\\`\\`\\`|\\*\\s|\\+\\s|\\-\\s|\\d+\\s))\\S+'  });
         case 'todo':
             return new Markdown_1.default({ code_start: '\`', code_end: '' });
         case 'plaintext':

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
           "default": [
             "markdown",
             "latex",
-            "plaintext"
+            "plaintext",
+            "quarto"
           ],
           "scope": "resource",
           "description": "Document types for which spelling will be turned ON by default."


### PR DESCRIPTION
Quarto is a new scientific and technical markdown publishing system (https://quarto.org). This PR registers the `quarto` filetype and registers it as a type that has spell-checking enabled by default.