### PR TITLE
Hack around Hunspell crashes on Supplementary Unicode plane codepoints

### DIFF
--- a/src/spellright.js
+++ b/src/spellright.js
@@ -766,7 +766,7 @@ var SpellRight = (function () {
         // the ancient Hunspell version bundled with node-spellchecker.
         // HACK: This bypasses spellcheck for those codepoints altogether.
         if (this.hunspell) {
-            cword = cword.replace(/[\ud800-\udbff][\ud800-\udfff]/g, ' ')
+            cword = cword.replace(/[\ud800-\udbff][\ud800-\udfff]/g, '  ')
         }
 
         // Hunspell does not understand curly apostrophe

--- a/src/spellright.js
+++ b/src/spellright.js
@@ -750,7 +750,6 @@ var SpellRight = (function () {
         var _containsApostrophe = /[\'\u2019]/.test(cword);
         var _containsDash = /[-]/.test(cword);
         var _containsDigitInside = /\D\d\D/.test(cword);
-        var _containsEmoji = /[\ue000-\uf8ff]|\ud83c[\udf00-\udfff]|\ud83d[\udc00-\ude4f]|\ud83d[\ude80-\udeff]/.test(cword);
         var _parentheticalPlural = /^\w+\((\w{1,2})\)$/.test(cword);
         var _containsParenthesis = /[\(\)]/.test(cword);
         var _possesiveApostrophe = /^\w+[\'\u2019]s$/.test(cword);
@@ -762,9 +761,12 @@ var SpellRight = (function () {
             if (/_+/.exec(cword)[0].length == cword.length) return;
         }
 
-        // Emojis crash Hunspell both on Linux and Windows
-        if (_containsEmoji && this.hunspell) {
-            return;
+        // Any Unicode codepoint outside BMP (U+0000...U+FFFF), i.e. U+10000...
+        // (which, among many other things, includes most emoji) crash
+        // the ancient Hunspell version bundled with node-spellchecker.
+        // HACK: This bypasses spellcheck for those codepoints altogether.
+        if (this.hunspell) {
+            cword = cword.replace(/[\ud800-\udbff][\ud800-\udfff]/g, ' ')
         }
 
         // Hunspell does not understand curly apostrophe


### PR DESCRIPTION
The [absolutely ancient] Hunspell version that was bundled with the SpellChecker Node bindings did not have a fully functional support for full Unicode at the time, and it crashes when faced with non-BMP (`U+10000`...) codepoints (those include most emoji, among many other things). So we just replace all of those with spaces here.

This fixes #284, fixes #450 and fixes #511.

A more robust solution would entail updating Hunspell in SpellChecker.

[absolutely ancient]: https://github.com/bartosz-antosik/vscode-spellright/blob/20482cda5458ac37f712fa224312359727005776/lib/bin/node-spellchecker/vendor/hunspell/ChangeLog#L1