### PR TITLE
Bugfix/fix bindings loading

### DIFF
--- a/lib/bindings.js
+++ b/lib/bindings.js
@@ -10,6 +10,7 @@
 
 const path = require('path');
 const glob = require('glob');
+const vscode = require('vscode');
 
 var bindings = null;
 var Spellchecker = null;
@@ -20,6 +21,7 @@ const loadBinary = function (baseName) {
   });
 
   var binding = null;
+  const failures = [];
 
   nodeFiles.forEach((file) => {
     try {
@@ -30,14 +32,38 @@ const loadBinary = function (baseName) {
         }
       }
     } catch (e) {
+      failures.push([file, e]);
     }
   });
 
-  if (SPELLRIGHT_DEBUG_OUTPUT && !binding) {
-    console.log('[spellright] Found no bindings among these files:');
-    nodeFiles.forEach((file) => {
-      console.log(file);
-    });
+  if (!binding) {
+    if (SPELLRIGHT_DEBUG_OUTPUT) {
+      console.log('[spellright] Found no bindings among these files:');
+      nodeFiles.forEach((file) => {
+        console.log(file);
+      });
+    }
+
+    // Write the failed bindings to an output channel so that
+    // users can provide this information to assist with debugging.
+    const channel = vscode.window.createOutputChannel('Spell Right');
+
+    channel.appendLine(`Could not find any bindings for the ${process.arch} architecture.`);
+
+    if (nodeFiles.length > 0) {
+      channel.appendLine('Attempted to load the following binding files:');
+
+      failures.forEach(([file, e]) => {
+        channel.appendLine(`${file} : ${e.message.replace(/\r?\n/g, '\n  ')}.`);
+      });
+    }
+
+    // Show an error to the user so that they
+    // know the extension is not working.
+    vscode.window.showErrorMessage('Spell Right is currently unavailable. A new version of this extension may be needed to support this version of VS Code.');
+
+    // Throw an error so that the extension stops loading.
+    throw new Error('No bindings were found.');
   }
 
   return binding;

--- a/lib/bindings.js
+++ b/lib/bindings.js
@@ -15,14 +15,16 @@ var bindings = null;
 var Spellchecker = null;
 
 const loadBinary = function (baseName) {
-  const nodeFiles = glob.globSync(path.join(__dirname, `bin/${baseName}*${process.arch}*.node`));
+  const nodeFiles = glob.globSync(`bin/${baseName}*${process.arch}*.node`, {
+    cwd: __dirname,
+  });
 
   var binding = null;
 
   nodeFiles.forEach((file) => {
     try {
       if (binding == null) {
-        binding = require(file);
+        binding = require(path.join(__dirname, file));
         if (SPELLRIGHT_DEBUG_OUTPUT) {
           console.log('[spellright] Bindings: \"' + path.basename(file) + '\".');
         }


### PR DESCRIPTION
Fixes #578.

The way that glob is used needed to be changed to specify `cwd` and use a relative search path.

I've also added logging to the output channel when no bindings are found, and an error message will be displayed so that users know that the extension is not working.