### PR TITLE
Pass `windowsPathsNoEscape: true` to `globSync` to ensure `glob` doesn't interpret Windows `\` path separators as escape characters

### DIFF
--- a/src/spellright.js
+++ b/src/spellright.js
@@ -2047,14 +2047,10 @@ var SpellRight = (function () {
     };
 
     SpellRight.prototype.readDictionaryFiles = function (pathName) {
-        let globPath = path.join(pathName, '.vscode', '*.dict');
+        const globPath = path.join(pathName, '.vscode', '*.dict');
 
-        if (require('os').platform() === 'win32') {
-            globPath = globPath.replaceAll('\\', '/');
-        }
+        const dictionaryFiles = glob.globSync(globPath, { windowsPathsNoEscape: true });
 
-        const dictionaryFiles = glob.globSync(globPath);
-        
         var result = [];
 
         dictionaryFiles.forEach((file) => {

--- a/src/spellright.js
+++ b/src/spellright.js
@@ -2047,7 +2047,14 @@ var SpellRight = (function () {
     };
 
     SpellRight.prototype.readDictionaryFiles = function (pathName) {
-        const dictionaryFiles = glob.globSync(path.join(pathName, '.vscode', '*.dict', ''));
+        let globPath = path.join(pathName, '.vscode', '*.dict');
+
+        if (require('os').platform() === 'win32') {
+            globPath = globPath.replaceAll('\\', '/');
+        }
+
+        const dictionaryFiles = glob.globSync(globPath);
+        
         var result = [];
 
         dictionaryFiles.forEach((file) => {


### PR DESCRIPTION
Fixes #584 and #590

Turns out a glob path issue is preventing workspace dictionaries to be recognized on Windows.

It's been happening for a few months now. I've now took the time to investigate the reason and it turns out that the [`glob` package](https://github.com/isaacs/node-glob) doesn't properly handle backslashes in standard windows paths. It's odd that such a popular package (made by the npm founder) can't do that, interesting.

I've verified that using a minimal test case:

```js
const path = require('path');
const glob = require('glob');

const path1 = `c:\\Test\\.vscode\\*.dict`;
const path2 = `c:/Test/.vscode/*.dict`;

console.log(glob.globSync(path1));
console.log(glob.globSync(path2));
```

* `path1` produces `[]`.
* `path2` produces a correct result.

The fix converts the backslashes to forward slashes, but only on Windows (to ensure not to corrupt Linux paths that may include `\`).

I've tested it, and it seems to fix the issue on my Windows 11 system.